### PR TITLE
Features/only major realeases oemof timeline

### DIFF
--- a/oemof_timeline/oemof_timeline.py
+++ b/oemof_timeline/oemof_timeline.py
@@ -23,7 +23,7 @@ names = events['description']
 dates = events['date']
 levels = events['level']
 
-fig, ax = plt.subplots(figsize=(12, 6))
+fig, ax = plt.subplots(figsize=(13, 6))
 
 # Create the base line
 start = min(dates)

--- a/oemof_timeline/oemof_timeline.py
+++ b/oemof_timeline/oemof_timeline.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python
 # coding: utf-8
+"""
+This script plots key events of the oemof community in a timeline.
+Below the arrow are meetings of the community like dev/user meetings.
+Above are major releases of the different libraries of oemof. In order
+not to overload the picture, minor releases have been omitted.
+"""
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import numpy as np

--- a/oemof_timeline/sorted_events.csv
+++ b/oemof_timeline/sorted_events.csv
@@ -20,6 +20,4 @@ date,description,level
 2018-11-05,8th dev meeting Flensburg,-1
 2019-05-15,9th dev/ 3rd user meeting Oldenburg,-2
 2019-06-05,oemof v0.3.0,2
-2019-06-11,oemof v0.3.1,2
-2019-11-29,oemof v0.3.2,1.5
 2019-12-04,10th dev meeting Berlin,-1


### PR DESCRIPTION
I removed the minor releases from the oemof-timeline
I extended the figsize. As time goes by, the arrow has to get longer in order not to squeeze things. One day a linebreak will be necessary.